### PR TITLE
Implicit integer conversion bugfix

### DIFF
--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -611,7 +611,7 @@
     UIViewController<PCStackViewController> *previousViewController;
 
     // Index of previous view controller
-    int previousViewControllerIndex = [self.childViewControllers indexOfObject:viewController] - 1;
+    NSUInteger previousViewControllerIndex = [self.childViewControllers indexOfObject:viewController] - 1;
 
     // View controller is revealing previous
     if (self.childViewControllers.count > previousViewControllerIndex) {


### PR DESCRIPTION
`int` 'tis just a wee little signed integer. `NSUInteger` is the full unsigned monty.
