### PR TITLE
[ready] Drag Handle, other such imrovements

### DIFF
--- a/PCStackNavigationController/PCStackNavigationController.h
+++ b/PCStackNavigationController/PCStackNavigationController.h
@@ -82,8 +82,8 @@
 
 @optional
 
-// If implemented, this scroll view will help determine if a gesture is navigational
-@property (nonatomic, strong) UIScrollView *scrollView;
+// If implemented, the view controller will only be navigable w/ a gesture on this view
+@property (nonatomic, strong) UIView *navigationHandle;
 
 // If present this will be called when the view controller is about to reappear
 // on the stack after the view controller above it was popped

--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -454,8 +454,10 @@
     // Check for navigationHandle
     if ([viewController respondsToSelector:@selector(navigationHandle)]) {
 
+        CGPoint gestureLocationInViewController = [gesture locationInView:viewController.view];
+
         // <PCStackViewController> has navigationHandle, ensure gesture is within its bounds. If not, gestureIsNavigation = false
-        if (![self point:gestureLocation isWithinBounds:viewController.navigationHandle.frame]) {
+        if (![self point:gestureLocationInViewController isWithinBounds:viewController.navigationHandle.frame]) {
             gestureIsNavigational = false;
         }
 

--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -383,7 +383,7 @@
         };
 
         // Add animation with key stackNav.dismiss so we know not to let the user navigate while it's dismissing
-        [viewController.view pop_addAnimation:springAnimation forKey:@"stackNav.dismiss"];
+        [viewController.view.layer pop_addAnimation:springAnimation forKey:@"stackNav.dismiss"];
 
         // Update scale and opacity of previous vc animated
         [self updatePreviousViewWithOpacity:1 scale:1 animated:YES];
@@ -497,15 +497,15 @@
             while (possibleViewController = [reverseControllerEnumerator nextObject]) {
 
                 // Fixes corner case where new view controller is pushed before another's dismissal has completed
-                if (![possibleViewController pop_animationForKey:@"stackNav.dismiss"]) {
+                if (![possibleViewController.view.layer pop_animationForKey:@"stackNav.dismiss"]) {
                     viewController = possibleViewController;
                     break;
                 }
-
             }
         }
 
         if (viewController) {
+
             // Remove animations before updating
             [viewController pop_removeAllAnimations];
 


### PR DESCRIPTION
![](http://i.imgur.com/J2rJ1dl.gif)

Adds a PCStackViewController protocol property `handle` to designate a certain view whose area should be the only draggable area for navigating the view controller. Especially useful on view controllers w/ UIScrollViews. Leave out the property to allow navigation by dragging any part of the view controller.

Also hides the previous view controller completely upon push to fix an issue with overlapping and ugly-lookin' view controllers when fading/scaling back.
