### PR TITLE
Horizontal transitions

### DIFF
--- a/PCStackNavigationController/PCStackNavigationController.h
+++ b/PCStackNavigationController/PCStackNavigationController.h
@@ -31,6 +31,9 @@
 // View controller at the bottom of the stack
 @property (nonatomic, weak) UIViewController<PCStackViewController> *bottomViewController;
 
+// Gesture recognizer that does a lot of hard work thank you, gesture recognizer, for all your dedication
+@property (nonatomic, strong) UIPanGestureRecognizer *panGestureRecognizer;
+
 // Returns the top (i.e. last) view controller in viewControllers
 - (UIViewController<PCStackViewController> *)topViewController;
 

--- a/PCStackNavigationController/PCStackNavigationController.h
+++ b/PCStackNavigationController/PCStackNavigationController.h
@@ -86,7 +86,7 @@
 @optional
 
 // If implemented, the view controller will only be navigable w/ a gesture on this view
-@property (nonatomic, strong) UIView *navigationHandle;
+@property (nonatomic) CGRect navigationHandle;
 
 // If implemented, this will be called when the view controller is about to reappear
 // on the stack after the view controller above it was popped

--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -451,7 +451,7 @@ typedef void(^completion_block)(POPAnimation *animation, BOOL completed);
         CGPoint gestureLocationInViewController = [gesture locationInView:viewController.view];
 
         // <PCStackViewController> has navigationHandle, ensure gesture is within its bounds. If not, gestureIsNavigation = false
-        if (![self point:gestureLocationInViewController isWithinBounds:viewController.navigationHandle.frame]) {
+        if (![self point:gestureLocationInViewController isWithinBounds:viewController.navigationHandle]) {
             gestureIsNavigational = false;
         }
 

--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -255,6 +255,9 @@
             // On completion, remove from superview and self
             springAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
 
+                // Re-enable UI after animation
+                self.view.userInteractionEnabled = true;
+
                 // Check that animation successfully completed (wasn't interrupted by another gesture)
                 if (completed) {
 
@@ -266,6 +269,9 @@
                 }
             };
         }
+
+        // Disable while animating
+        self.view.userInteractionEnabled = false;
 
         // Add the animation
         [viewController.view.layer pop_addAnimation:springAnimation forKey:@"stackNav.dismiss"];
@@ -330,6 +336,7 @@
         // Re-enabled previous upon completion
         // TODO: maybe find a better solution that doesn't prevent immediate dismissal unless we want immediate dismissal for accident prevention
         springEnterAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
+
             self.view.userInteractionEnabled = true;
 
             // Grab previous view controller
@@ -395,6 +402,9 @@
 
     if (animated) {
 
+        // Disable while animating
+        self.view.userInteractionEnabled = false;
+
         // Spring animation
         POPSpringAnimation *springAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPositionY];
         springAnimation.springBounciness = 0;
@@ -406,6 +416,9 @@
         if ([self shouldPopViewController:viewController animated:animated]) {
             // On completion, remove from superview and self
             springAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
+
+                // Re-enable UI after animation
+                self.view.userInteractionEnabled = true;
 
                 // Check that animation successfully completed (wasn't interrupted by another gesture)
                 if (completed) {

--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -11,9 +11,11 @@
 
 @implementation PCStackNavigationController
 
+typedef void(^completion_block)(POPAnimation *animation, BOOL completed);
+
 #define SPRING_BOUNCINESS 1
-#define SPRING_SPEED 6
-#define DISMISS_VELOCITY_THRESHOLD 150
+#define SPRING_SPEED 4
+#define DISMISS_VELOCITY_THRESHOLD 250
 #define DOWN_SCALE 0.95
 #define DOWN_OPACITY 0.8
 
@@ -214,61 +216,39 @@
     CGFloat newPrevScale;
 
     // Spring animation
-    POPSpringAnimation *springAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPositionY];
-    springAnimation.springBounciness = SPRING_BOUNCINESS;
-    springAnimation.springSpeed = SPRING_SPEED;
-    springAnimation.velocity = @(velocity.y);
+    POPSpringAnimation *springAnimation;
 
-    if (velocity.y > DISMISS_VELOCITY_THRESHOLD && viewController.stackIndex > 0) {
+    // Popability check
+    BOOL shouldPop = [self shouldPopViewController:viewController animated:YES];
 
-        // Dismiss view gesture, check popability
-        BOOL shouldPop = [self shouldPopViewController:viewController animated:YES];
+    if (velocity.y > DISMISS_VELOCITY_THRESHOLD && viewController.stackIndex > 0 && shouldPop == true) {
 
-        if (shouldPop) {
-            // Should pop, animation should go off screen
-            springAnimation.toValue = @(self.view.frame.size.height * 1.5);
+        // Should pop, animation should go off screen
+        springAnimation = [self springDismissAnimationWithVelocity:velocity.y completion:^(POPAnimation *animation, BOOL completed) {
+            // Re-enable UI after animation
+            self.view.userInteractionEnabled = true;
 
-            newPrevOpacity = 1;
-            newPrevScale = 1;
-        } else {
-            // Shouldn't pop, animation should return to resting center
-            CGPoint restingCenter = [self restingCenterForViewController:self.topViewController];
-            springAnimation.toValue = @(restingCenter.y);
-
-            newPrevOpacity = DOWN_OPACITY;
-            newPrevScale = DOWN_SCALE;
-        }
-
-        springAnimation.springBounciness = 0;
-
-        if (shouldPop) {
-            NSInteger belowIndex = self.topViewController.stackIndex - 1;
-            if (belowIndex >= 0) {
-                UIViewController<PCStackViewController> *belowViewController = [self.childViewControllers objectAtIndex:belowIndex];
-
-                // See if we can send it a viewWillAppear so it knows it's about to appear again
-                if ([belowViewController respondsToSelector:@selector(viewWillReappear:)]) {
-                    [belowViewController viewWillReappear:YES];
-                }
+            // Check that animation successfully completed (wasn't interrupted by another gesture)
+            if (completed) {
+                // Not interrupted, remove from super view and self
+                [viewController.view removeFromSuperview];
+                [viewController removeFromParentViewController];
+                [self.topViewController viewDidAppear:YES];
             }
+        }];
 
-            // On completion, remove from superview and self
-            springAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
+        UIViewController<PCStackViewController> *previousViewController = [self viewControllerBeforeViewController:viewController];
 
-                // Re-enable UI after animation
-                self.view.userInteractionEnabled = true;
+        if (previousViewController) {
 
-                // Check that animation successfully completed (wasn't interrupted by another gesture)
-                if (completed) {
-
-                    // Not interrupted, remove from super view and self
-                    [viewController.view removeFromSuperview];
-                    [viewController removeFromParentViewController];
-                    [self.topViewController viewDidAppear:YES];
-
-                }
-            };
+            // See if we can send it a viewWillAppear so it knows it's about to appear again
+            if ([previousViewController respondsToSelector:@selector(viewWillReappear:)]) {
+                [previousViewController viewWillReappear:YES];
+            }
         }
+
+        newPrevOpacity = 1;
+        newPrevScale = 1;
 
         // Disable while animating
         self.view.userInteractionEnabled = false;
@@ -281,8 +261,7 @@
         newPrevOpacity = DOWN_OPACITY;
         newPrevScale = DOWN_SCALE;
 
-        // Velocity is negative and below threshold (upward "throw" swipe)
-        springAnimation.toValue = @([self restingCenterForViewController:viewController].y);
+        springAnimation = [self springEnterAnimationWithVelocity:velocity.y viewController:viewController completion:nil];
 
         // Add the animation
         [viewController.view.layer pop_addAnimation:springAnimation forKey:@"stackNav.flick"];
@@ -327,16 +306,9 @@
         [self.view addSubview:incomingViewController.view];
 
         // Build spring animation to animate incoming into view
-        POPSpringAnimation *springEnterAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPositionY];
-
-        // Set spring animation bounciness and speed to stackNav defaults
-        springEnterAnimation.springBounciness = SPRING_BOUNCINESS;
-        springEnterAnimation.springSpeed = SPRING_SPEED;
-
-        // Re-enabled previous upon completion
+        // Re-enable previous upon completion
         // TODO: maybe find a better solution that doesn't prevent immediate dismissal unless we want immediate dismissal for accident prevention
-        springEnterAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
-
+        POPSpringAnimation *springEnterAnimation = [self springEnterAnimationWithVelocity:0 viewController:incomingViewController completion:^(POPAnimation *animation, BOOL completed) {
             self.view.userInteractionEnabled = true;
 
             // Grab previous view controller
@@ -350,10 +322,7 @@
                 previousViewController.view.layer.opacity = 0;
 
             }
-        };
-
-        // To value is resting center view incoming view controller
-        springEnterAnimation.toValue = @([self restingCenterForViewController:incomingViewController].y);
+        }];
 
         // Add spring enter animation to incoming view controller
         [incomingViewController.view.layer pop_addAnimation:springEnterAnimation forKey:@"stackNav.enter"];
@@ -362,7 +331,7 @@
 
     } else {
 
-        // Not animated so make sure frame (spec. origin) is correct upon adding as subview
+        // Not animated so make sure frame (spec. origin.y) is correct upon adding as subview
         CGRect viewFrame = incomingViewController.view.frame;
         viewFrame.origin.y = [self restingCenterForViewController:incomingViewController].y - (viewFrame.size.height / 2);
 
@@ -400,37 +369,28 @@
         }
     }
 
-    if (animated) {
+    BOOL shouldPop = [self shouldPopViewController:viewController animated:animated];
+
+    if (animated && shouldPop) {
 
         // Disable while animating
         self.view.userInteractionEnabled = false;
 
         // Spring animation
-        POPSpringAnimation *springAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPositionY];
-        springAnimation.springBounciness = 0;
-        springAnimation.springSpeed = SPRING_SPEED;
-
-        // Dismiss view gesture, send it off screen
-        springAnimation.toValue = @(self.view.frame.size.height * 1.5);
-
-        if ([self shouldPopViewController:viewController animated:animated]) {
+        POPSpringAnimation *springAnimation = [self springDismissAnimationWithVelocity:0 completion:^(POPAnimation *animation, BOOL completed) {
             // On completion, remove from superview and self
-            springAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
+            // Re-enable UI after animation
+            self.view.userInteractionEnabled = true;
 
-                // Re-enable UI after animation
-                self.view.userInteractionEnabled = true;
+            // Check that animation successfully completed (wasn't interrupted by another gesture)
+            if (completed) {
 
-                // Check that animation successfully completed (wasn't interrupted by another gesture)
-                if (completed) {
-
-                    // Not interrupted, remove from super view and self
-                    [viewController.view removeFromSuperview];
-                    [viewController removeFromParentViewController];
-                    [self.topViewController viewDidAppear:YES];
-
-                }
-            };
-        }
+                // Not interrupted, remove from super view and self
+                [viewController.view removeFromSuperview];
+                [viewController removeFromParentViewController];
+                [self.topViewController viewDidAppear:YES];
+            }
+        }];
 
         // Add animation with key stackNav.dismiss so we know not to let the user navigate while it's dismissing
         [viewController.view.layer pop_addAnimation:springAnimation forKey:@"stackNav.dismiss"];
@@ -438,7 +398,7 @@
         // Update scale and opacity of previous vc animated
         [self updatePreviousViewWithOpacity:1 scale:1 animated:YES];
 
-    } else {
+    } else if (shouldPop) {
 
         if ([self shouldPopViewController:viewController animated:animated]) {
 
@@ -623,7 +583,7 @@
     CGPoint restingCenter = [self restingCenterForViewController:viewController];
 
     // Build animation
-    POPSpringAnimation *springReturnAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPosition];
+    POPSpringAnimation *springReturnAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPositionY];
     springReturnAnimation.toValue = [NSValue valueWithCGPoint:restingCenter];
     springReturnAnimation.springBounciness = SPRING_BOUNCINESS;
     springReturnAnimation.springSpeed = SPRING_SPEED;
@@ -730,12 +690,34 @@
 
         // View controller underneath exists, use it to update status bar
         previousViewController = [self.childViewControllers objectAtIndex:previousViewControllerIndex];
-
     }
 
     return previousViewController;
 }
 
+#pragma mark animations
+
+- (POPSpringAnimation *)springCenterYAnimationWithVelocity:(CGFloat)velocity completion:(completion_block)completionBlock {
+    POPSpringAnimation *springAnimation = [POPSpringAnimation animationWithPropertyNamed:kPOPLayerPositionY];
+    springAnimation.springBounciness = SPRING_BOUNCINESS;
+    springAnimation.springSpeed = SPRING_SPEED;
+    springAnimation.velocity = @(velocity);
+    springAnimation.completionBlock = completionBlock;
+    return springAnimation;
+}
+
+- (POPSpringAnimation *)springEnterAnimationWithVelocity:(CGFloat)velocity viewController:(UIViewController<PCStackViewController> *)viewController completion:(completion_block)completionBlock {
+    POPSpringAnimation *springAnimation = [self springCenterYAnimationWithVelocity:velocity completion:completionBlock];
+    springAnimation.toValue = @([self restingCenterForViewController:viewController].y);
+    return springAnimation;
+}
+
+- (POPSpringAnimation *)springDismissAnimationWithVelocity:(CGFloat)velocity completion:(completion_block)completionBlock {
+    POPSpringAnimation *springAnimation = [self springCenterYAnimationWithVelocity:velocity completion:completionBlock];
+    springAnimation.toValue = @(self.view.frame.size.height * 1.5);
+    springAnimation.springBounciness = 0;
+    return springAnimation;
+}
 
 #pragma mark etc.
 

--- a/PCStackNavigationController/PCStackNavigationController.m
+++ b/PCStackNavigationController/PCStackNavigationController.m
@@ -242,6 +242,16 @@
         springAnimation.springBounciness = 0;
 
         if (shouldPop) {
+            NSInteger belowIndex = self.topViewController.stackIndex - 1;
+            if (belowIndex >= 0) {
+                UIViewController<PCStackViewController> *belowViewController = [self.childViewControllers objectAtIndex:belowIndex];
+
+                // See if we can send it a viewWillAppear so it knows it's about to appear again
+                if ([belowViewController respondsToSelector:@selector(viewWillReappear:)]) {
+                    [belowViewController viewWillReappear:YES];
+                }
+            }
+
             // On completion, remove from superview and self
             springAnimation.completionBlock = ^(POPAnimation *animation, BOOL completed) {
 


### PR DESCRIPTION
The more I played with Stack Nav, and especially on larger devices, I realized how difficult it could be to reach to the top nav bar to perform a dismissal gesture. The alternative, tapping the top left icon to dismiss, is even harder.

I've made all view controllers animate in from the right side of the screen, and pop out by sliding back to where they came from. This affords a more intuitive visual/spatial hierarchy, more similar to that found in the stock `UINavigationController`. Because of that, we can also take advantage of the now ubiquitous swipe-from-left-edge to go back a level in the stack. Yay!

TODO: Planning on adding an optional PCStackViewController method to let the controller know whether to use a vertical or horizontal animation. Vertical animations are often found for content creation view controllers and other view controllers that shouldn't allow for gestural dismissal. This makes most sense for, like I said, content creation, where you want to request some sort of confirmation from the user before potentially deleting something they may have typed or created. View controllers that navigate vertically will only allow for dismissal via an explicit call to stackController.
