### PR TITLE
UIViewController appearance methods

### DIFF
--- a/PCStackNavigationController/PCStackNavigationController.h
+++ b/PCStackNavigationController/PCStackNavigationController.h
@@ -91,13 +91,9 @@
 // If implemented, the view controller will only be navigable w/ a gesture on this view
 @property (nonatomic) CGRect navigationHandle;
 
-// If implemented, this will be called when the view controller is about to reappear
-// on the stack after the view controller above it was popped
-- (void)viewWillReappear:(BOOL)animated;
-
-// If implemented, this will be called immediately before the view controller
-// begins animating downward and if false spring stops around halfway.
-// Note that returning false does NOT return the view controller to visibility. (see returnViewControllerToRestingCenter:completion:)
+/** If implemented, this will be called immediately before the view controller
+begins animating downward and if false spring stops around halfway.
+Note that returning false does NOT return the view controller to visibility. (see returnViewControllerToRestingCenter:completion:) */
 - (BOOL)shouldPopAnimated:(BOOL)animated;
 
 // If implemented, this method will be called on a view controller being pushed


### PR DESCRIPTION
I was doing some silly things trying to call appearance methods like `viewWillAppear`, `viewDidAppear`, `viewWillDisappear`, and `viewDidDisappear` manually. Instead, the `UIViewController` interface has some super nifty methods to be used by container view controllers. (read about [view controller containment](http://www.objc.io/issue-1/containment-view-controller.html))

These methods are:
- `- (void)beginAppearanceTransition:(BOOL)isAppearing animated:(BOOL)animated;` where `isAppearing` is `true` when appearing and `false` when disappearing.
- `- (void)endAppearanceTransition;` signifies that the transition has completed;

So yeah. Whoops. Now we're using these.

related: it looks like each method can only be called twice per view controller, once for appearance and once for disappearance.
